### PR TITLE
Disable trigger for PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,8 @@ name: 'Backend pipeline'
 trigger:
 - master
 
+pr: none
+
 pool:
   vmImage: 'windows-latest'
 


### PR DESCRIPTION
If is not disabled, by default is every PR built and with continuous delivery published to "production"